### PR TITLE
The internal server error was because we were checking for a null val…

### DIFF
--- a/server/controllers/lighthouse.js
+++ b/server/controllers/lighthouse.js
@@ -146,7 +146,7 @@ class LighthouseControllers {
       let cResults = [];
       for (let pResult of results) {
         cResults.push(pResult._source.name);
-        if (pResult._source.value !== undefined) {
+        if (pResult._source.value.stream !== undefined) {
           cResults.push(pResult._source.value.stream.metadata.title);
           cResults.push(pResult._source.value.stream.metadata.author);
         }


### PR DESCRIPTION
The internal server error was because we were checking for a null value for a claim. This is already checked and should never be null. The intention is to make sure we can get the right information out which is only available in a stream. However, there is no stream for channel claims, only certificates. So the fix is to check for null on the stream not the value.