### PR TITLE
Fixed the gendb script for compability with new curl versions.

### DIFF
--- a/gendb.sh
+++ b/gendb.sh
@@ -5,6 +5,6 @@ then
    exit 1;
 else
    echo "Index did not exist, creating..." ;
-   curl -X PUT http://localhost:9200/claims -H '"Content-Type: application/json"'-d '{ "settings" : { "number_of_shards" : 1 }, "mappings" : { "claim" : { "properties" : { "value" : { "type" : "nested" }, "suggest_name": { "type": "completion" }, "suggest_desc": { "type": "completion" } } } } }';
+   curl -H 'Content-Type: application/json' -H 'Accept: application/json' -X PUT -d '{ "settings" : { "number_of_shards" : 1 }, "mappings" : { "claim" : { "properties" : { "value" : { "type" : "nested" }, "suggest_name": { "type": "completion" }, "suggest_desc": { "type": "completion" } } } } }' http://localhost:9200/claims;
    exit 0;
 fi


### PR DESCRIPTION
As of Ubuntu 18.04, curl 7.58.0 did not like the JSON scheme of the index creation script.
This causes the search to stop working as it then cannot search the nested values.
This pull fixes that issue and allows the creation of the index to work on all systems running curl.