### PR TITLE
fixed pull_request typo.

### DIFF
--- a/server/controllers/lighthouse.js
+++ b/server/controllers/lighthouse.js
@@ -448,7 +448,7 @@ class LighthouseControllers {
     if (status) {
       let notification = JSON.parse(payload);
       if (notification.branch === 'master') {
-        if (!notification.isPullRequest) {
+        if (!notification.pull_request) {
           logToSlack('Auto Updating Lighthouse - ' + notification.message);
           update();
           ctx.body = 'OK';


### PR DESCRIPTION
looks like there is a typo. From the travis docs:
<img width="465" alt="screen shot 2018-11-08 at 9 19 10 am" src="https://user-images.githubusercontent.com/3402064/48204536-09fc3f00-e338-11e8-959f-36fd98eb599e.png">

The CD is deploying on pull requests ( not deploying the pull request but uselessly going through the process on a pull request because the field is undefined.
