### PR TITLE
Add channel_id parameter to search api

### DIFF
--- a/server/controllers/lighthouse.js
+++ b/server/controllers/lighthouse.js
@@ -41,6 +41,19 @@ function getResults (input) {
   let washedQuery = getEscapedQuery(getWashedQuery(trimmedQuery));
   let effectiveFactor = '0.00000000001';
   // Search is split up into different parts, all search parts goes under this line.
+  let channelidSearch;
+  if (input.channel_id !== undefined) {
+    channelidSearch = { // If we got a channel_id argument, lets filter out only that channel_id
+      'bool': {
+        'must': {
+          'query_string': {
+            'fields': ['channel_id'],
+            'query' : getEscapedQuery(input.channel_id.trim()),
+          },
+        },
+      },
+    };
+  }
   let channelSearch;
   if (input.channel !== undefined) { // If we got a channel argument, lets filter out only that channel
     channelSearch = {
@@ -256,6 +269,7 @@ function getResults (input) {
           ],
           'must': [
             channelSearch,
+            channelidSearch,
             {
               'bool': {
                 'should': [


### PR DESCRIPTION
Add channel_id parameter to search to restrict results to claims published to a specific channel's claim_id. This helps refine search for channels that have many bidding with the same name.